### PR TITLE
Add support for Credo's inline configuration

### DIFF
--- a/lib/engine_credo/runner.ex
+++ b/lib/engine_credo/runner.ex
@@ -6,16 +6,18 @@ defmodule EngineCredo.Runner do
   """
 
   alias EngineCredo.{Issue,Config}
+  alias Credo.CLI.Filter
 
   def check(%Config{credo_config: config, source_files: files, source_code_path: path_prefix}) do
     {checked_source_files, _} = Credo.Check.Runner.run(files, config)
 
-    extract_issues(checked_source_files, path_prefix)
+    extract_issues(checked_source_files, path_prefix, config)
   end
 
-  defp extract_issues(source_files, path_prefix) do
+  defp extract_issues(source_files, path_prefix, config) do
     source_files
-    |> Stream.flat_map(&(&1.issues))
-    |> Stream.map(&Issue.convert(&1, path_prefix))
+    |> Enum.flat_map(&(&1.issues))
+    |> Filter.valid_issues(config)
+    |> Enum.map(&Issue.convert(&1, path_prefix))
   end
 end

--- a/test/engine_credo/config_test.exs
+++ b/test/engine_credo/config_test.exs
@@ -43,8 +43,12 @@ defmodule EngineCredo.ConfigTest do
   test "finds elixir files to check" do
     %{source_files: files} = Config.read
 
-    [%Credo.SourceFile{filename: file}] = files
-    assert "test/fixtures/project_root/lib/design_issues.exs" == file
+    found_files = [
+      "test/fixtures/project_root/lib/design_issues.exs",
+      "test/fixtures/project_root/lib/ignore_via_attribute.exs"
+    ]
+
+    assert found_files == Enum.map(files, &(&1.filename))
   end
 
   test "finds elixir that are not valid to check" do

--- a/test/fixtures/project_root/lib/ignore_via_attribute.exs
+++ b/test/fixtures/project_root/lib/ignore_via_attribute.exs
@@ -1,0 +1,8 @@
+defmodule IgnoreViaAttribute do
+  @moduledoc false
+
+  @lint {Credo.Check.Design.TagTODO, false}
+  def fun do
+    # TODO: This TODO should not be reported
+  end
+end


### PR DESCRIPTION
As explained at https://github.com/rrrene/credo#inline-configuration-via-lint-attributes

This replicate some of the `Credo.Check.Runner` internals that extracts the `@lint` attribute from source files and ignore them when writing to stdout.