### PR TITLE
upgrade credo to 1.0.1

### DIFF
--- a/lib/engine_credo/config.ex
+++ b/lib/engine_credo/config.ex
@@ -57,7 +57,8 @@ defmodule EngineCredo.Config do
 
   defp read_config_file(path) do
     # true required for safe loading of `.credo.exs`.
-    Credo.ConfigFile.read_or_default(path, nil, true)
+    {:ok, result} = Credo.ConfigFile.read_or_default(path, nil, true)
+    result
   end
 
   defp reject_disabled_checks(engine_config) do
@@ -105,7 +106,7 @@ defmodule EngineCredo.Config do
     execution
     |> Credo.Sources.find()
     |> Enum.filter(&String.ends_with?(&1.filename, [".ex", ".exs"]))
-    |> Enum.split_with(& &1.valid?)
+    |> Enum.split_with(fn x -> x.status == :valid end)
   end
 
   defp load_comment_configuration(execution, source_files) do
@@ -119,7 +120,7 @@ defmodule EngineCredo.Config do
 
   defp boostrap(execution) do
     execution
-    |> Credo.Execution.Issues.start_server()
+    |> Credo.Execution.ExecutionIssues.start_server()
     # TODO: Remove this once stop supporting the inline attribute configuration.
     |> Credo.CLI.Output.UI.use_colors()
   end

--- a/lib/engine_credo/issue_categories.ex
+++ b/lib/engine_credo/issue_categories.ex
@@ -58,6 +58,7 @@ defmodule EngineCredo.IssueCategories do
     Credo.Check.Refactor.LongQuoteBlocks => "Clarity",
     Credo.Check.Refactor.MapInto => "Clarity",
 
+    Credo.Check.Warning.UnsafeToAtom => "Bug Risk",
     Credo.Check.Warning.BoolOperationOnSameValues => "Bug Risk",
     Credo.Check.Warning.IExPry => "Bug Risk",
     Credo.Check.Warning.IoInspect => "Bug Risk",

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule EngineCredo.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:credo, "~> 0.10"},
+      {:credo, "~> 1.0"},
       {:poison, "~> 2.2"},
       {:briefly, "~> 0.3", only: :test}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "briefly": {:hex, :briefly, "0.3.0", "16e6b76d2070ebc9cbd025fa85cf5dbaf52368c4bd896fb482b5a6b95a540c2f", [:mix], [], "hexpm"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
-  "credo": {:hex, :credo, "0.10.0", "66234a95effaf9067edb19fc5d0cd5c6b461ad841baac42467afed96c78e5e9e", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
-  "jason": {:hex, :jason, "1.1.1", "d3ccb840dfb06f2f90a6d335b536dd074db748b3e7f5b11ab61d239506585eb2", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "credo": {:hex, :credo, "1.0.1", "5a5bc382cf0a12cc7db64cc018526aee05db572c60e867f6bc4b647d7ef9fc61", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
+  "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], [], "hexpm"},
 }

--- a/test/engine_credo/config_test.exs
+++ b/test/engine_credo/config_test.exs
@@ -15,7 +15,7 @@ defmodule EngineCredo.ConfigTest do
     ]
 
     assert expected_included_paths == execution.files.included
-    assert Enum.member?(execution.checks, {Credo.Check.Warning.IExPry})
+    assert Enum.member?(execution.checks, {Credo.Check.Warning.IExPry, []})
   end
 
   test "merges paths from the engine config" do

--- a/test/engine_credo/formatter_test.exs
+++ b/test/engine_credo/formatter_test.exs
@@ -6,11 +6,12 @@ defmodule EngineCredo.FormatterTest do
   alias EngineCredo.{Config, Formatter, Runner}
 
   test "prints issues as JSON separated by \\0 and \\n" do
-    output = capture_io(fn ->
-      Config.read
-      |> Runner.check
-      |> Formatter.print
-    end)
+    output =
+      capture_io(fn ->
+        Config.read()
+        |> Runner.check()
+        |> Formatter.print()
+      end)
 
     issues = [
       ~S({"type":"issue","remediation_points":100000,"location":{"path":"lib/design_issues.exs","lines":{"end":5,"begin":5}},"description":"Found a FIXME tag in a comment: # FIXME: issue","check_name":"Elixir.Credo.Check.Design.TagFIXME","categories":["Bug Risk"]}),
@@ -24,9 +25,10 @@ defmodule EngineCredo.FormatterTest do
   end
 
   test "prints a warning for each invalid source file detected" do
-    output = capture_io(:stderr, fn ->
-      Formatter.error(Config.read)
-    end)
+    output =
+      capture_io(:stderr, fn ->
+        Formatter.error(Config.read())
+      end)
 
     first_error = "Invalid file detected test/fixtures/project_root/lib/invalid_elixir.exs\n"
     second_error = "Invalid file detected test/fixtures/project_root/lib/non_utf8.exs\n"


### PR DESCRIPTION
# motivation
update credo to the lates version mostly because the one currently in use has a bug on the alias order check

# changes
- Credo.SourceFile struct now has a `status` key  instead of the old `valid?`one, changed our `EngineCredo.Config. find_source_files\1` to work with that
- `Credo.ConfigFile.read_or_default` now returns {:ok, result} instead of result, added pattern matching on `EngineCredo.Config. find_source_files.read_config_file\1` to get only the result
- `Credo.Execution.Issues` was renamed to `Credo.Execution.ExecutionIssues`, changed to the new name everywhere it was being called
- add `Credo.Check.Warning.UnsafeToAtom` to `issue_categories`
- the checks now return an empty list  in the tuple along with the check when there's nothing instead of just the check name