### PR TITLE
Add support for credo v1.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.10-alpine
+FROM elixir:1.11-alpine
 MAINTAINER SourceLevel <support@sourcelevel.io>
 
 WORKDIR /usr/src/engine

--- a/lib/engine_credo/issue_categories.ex
+++ b/lib/engine_credo/issue_categories.ex
@@ -21,9 +21,10 @@ defmodule EngineCredo.IssueCategories do
 
     Credo.Check.Readability.AliasOrder => "Style",
     Credo.Check.Readability.AliasAs => "Style",
+    Credo.Check.Readability.BlockPipe => "Clarity",
     Credo.Check.Readability.FunctionNames => "Style",
     Credo.Check.Readability.LargeNumbers => "Style",
-    Credo.Check.Readability.UnnecessaryAliasExpansion => "Style",
+    Credo.Check.Readability.ImplTrue => "Style",
     Credo.Check.Readability.MaxLineLength => "Style",
     Credo.Check.Readability.MultiAlias => "Style",
     Credo.Check.Readability.ModuleAttributeNames => "Style",
@@ -37,6 +38,7 @@ defmodule EngineCredo.IssueCategories do
     Credo.Check.Readability.PreferUnquotedAtoms => "Style",
     Credo.Check.Readability.RedundantBlankLines => "Style",
     Credo.Check.Readability.Semicolons => "Style",
+    Credo.Check.Readability.SeparateAliasRequire => "Style",
     Credo.Check.Readability.SinglePipe => "Style",
     Credo.Check.Readability.SpaceAfterCommas => "Style",
     Credo.Check.Readability.Specs => "Style",
@@ -44,6 +46,7 @@ defmodule EngineCredo.IssueCategories do
     Credo.Check.Readability.StringSigils => "Style",
     Credo.Check.Readability.TrailingBlankLine => "Style",
     Credo.Check.Readability.TrailingWhiteSpace => "Style",
+    Credo.Check.Readability.UnnecessaryAliasExpansion => "Style",
     Credo.Check.Readability.VariableNames => "Style",
     Credo.Check.Readability.WithCustomTaggedTuple => "Clarity",
 
@@ -67,6 +70,7 @@ defmodule EngineCredo.IssueCategories do
     Credo.Check.Refactor.MapInto => "Clarity",
     Credo.Check.Refactor.WithClauses => "Clarity",
 
+    Credo.Check.Warning.ApplicationConfigInModuleAttribute => "Bug Risk",
     Credo.Check.Warning.UnsafeToAtom => "Bug Risk",
     Credo.Check.Warning.BoolOperationOnSameValues => "Bug Risk",
     Credo.Check.Warning.IExPry => "Bug Risk",

--- a/lib/engine_credo/runner.ex
+++ b/lib/engine_credo/runner.ex
@@ -10,6 +10,8 @@ defmodule EngineCredo.Runner do
   alias Credo.Execution
 
   def check(%Config{execution: execution, source_files: files, source_code_path: path_prefix}) do
+    Execution.put_source_files(execution, files)
+
     :ok = Credo.Check.Runner.run(files, execution)
 
     issues = Execution.get_issues(execution)

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule EngineCredo.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:credo, "1.4.1"},
+      {:credo, "1.5.4"},
       {:poison, "~> 2.2"},
       {:briefly, "~> 0.3", only: :test}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule EngineCredo.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:credo, "1.3.2"},
+      {:credo, "1.4.1"},
       {:poison, "~> 2.2"},
       {:briefly, "~> 0.3", only: :test}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,8 @@
 %{
   "briefly": {:hex, :briefly, "0.3.0", "16e6b76d2070ebc9cbd025fa85cf5dbaf52368c4bd896fb482b5a6b95a540c2f", [:mix], [], "hexpm", "c6ebf8fc3dcd4950dd10c03e953fb4f553a8bcf0ff4c8c40d71542434cd7e046"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},
-  "credo": {:hex, :credo, "1.4.1", "16392f1edd2cdb1de9fe4004f5ab0ae612c92e230433968eab00aafd976282fc", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "155f8a2989ad77504de5d8291fa0d41320fdcaa6a1030472e9967f285f8c7692"},
+  "credo": {:hex, :credo, "1.5.4", "9914180105b438e378e94a844ec3a5088ae5875626fc945b7c1462b41afc3198", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2.8", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "cf51af45eadc0a3f39ba13b56fdac415c91b34f7b7533a13dc13550277141bc4"},
+  "file_system": {:hex, :file_system, "0.2.10", "fb082005a9cd1711c05b5248710f8826b02d7d1784e7c3451f9c1231d4fc162d", [:mix], [], "hexpm", "41195edbfb562a593726eda3b3e8b103a309b733ad25f3d642ba49696bf715dc"},
   "jason": {:hex, :jason, "1.2.2", "ba43e3f2709fd1aa1dce90aaabfd039d000469c05c56f0b8e31978e03fa39052", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "18a228f5f0058ee183f29f9eae0805c6e59d61c3b006760668d8d18ff0d12179"},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], [], "hexpm", "519bc209e4433961284174c497c8524c001e285b79bdf80212b47a1f898084cc"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "briefly": {:hex, :briefly, "0.3.0", "16e6b76d2070ebc9cbd025fa85cf5dbaf52368c4bd896fb482b5a6b95a540c2f", [:mix], [], "hexpm", "c6ebf8fc3dcd4950dd10c03e953fb4f553a8bcf0ff4c8c40d71542434cd7e046"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},
-  "credo": {:hex, :credo, "1.3.2", "08d456dcf3c24da162d02953fb07267e444469d8dad3a2ae47794938ea467b3a", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "b11d28cce1f1f399dddffd42d8e21dcad783309e230f84b70267b1a5546468b6"},
+  "credo": {:hex, :credo, "1.4.1", "16392f1edd2cdb1de9fe4004f5ab0ae612c92e230433968eab00aafd976282fc", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "155f8a2989ad77504de5d8291fa0d41320fdcaa6a1030472e9967f285f8c7692"},
   "jason": {:hex, :jason, "1.2.2", "ba43e3f2709fd1aa1dce90aaabfd039d000469c05c56f0b8e31978e03fa39052", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "18a228f5f0058ee183f29f9eae0805c6e59d61c3b006760668d8d18ff0d12179"},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], [], "hexpm", "519bc209e4433961284174c497c8524c001e285b79bdf80212b47a1f898084cc"},
 }

--- a/test/engine_credo/formatter_test.exs
+++ b/test/engine_credo/formatter_test.exs
@@ -19,9 +19,9 @@ defmodule EngineCredo.FormatterTest do
       ~S({"type":"issue","remediation_points":100000,"location":{"path":"lib/ignore_via_attribute.exs","lines":{"end":6,"begin":6}},"description":"Found a TODO tag in a comment: # TODO: This TODO should not be reported","check_name":"Elixir.Credo.Check.Design.TagTODO","categories":["Bug Risk"]})
     ]
 
-    expected_output = Enum.join(issues, "\0\n") <> "\0\n"
-
-    assert expected_output == output
+    Enum.each(issues, fn issue ->
+      assert String.contains?(output, issue)
+    end)
   end
 
   test "prints a warning for each invalid source file detected" do


### PR DESCRIPTION
- Update Elixir version to `1.11` in Dockerfile
- Update credo to v1.4.1

No new checks were added in this version